### PR TITLE
use https instead of ssh git submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spark-wallet"]
 	path = spark-wallet
-	url = git@github.com:shesek/spark-wallet.git
+	url = https://github.com/shesek/spark-wallet.git


### PR DESCRIPTION
Aside from being recommended by GH, it removes need of ssh setup 