### PR TITLE
Don't crash when no payments exist

### DIFF
--- a/spark-methods.go
+++ b/spark-methods.go
@@ -80,7 +80,7 @@ var listpaysExt = plugin.RPCMethod{
 
 		retval := make([]interface{}, len(pays))
 		// these are not currently available, but be prepared for when they are
-		if pays[0].Get("payment_hash").Exists() && pays[0].Get("created_at").Exists() {
+		if len(pays) > 0 && pays[0].Get("payment_hash").Exists() && pays[0].Get("created_at").Exists() {
 			for i, pay := range pays {
 				retval[i] = pay.Value()
 			}


### PR DESCRIPTION
On fresh setup:

```
panic: runtime error: index out of range [0] with length 0

goroutine 106 [running]:
main.glob..func3(0xc0000fe0f0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/app/spark-methods.go:83 +0x918
github.com/fiatjaf/lightningd-gjson-rpc/plugin.handleMessage(0xc0000fe0f0, 0xc000094190, 0x0, 0x0, 0x8a6620, 0xc0005a8610, 0xc0005a8620, 0xb, 0x8a2b60, 0xc0000b4fc0)
	/go/pkg/mod/github.com/fiatjaf/lightningd-gjson-rpc@v1.0.1/plugin/plugin.go:204 +0x5b9
created by github.com/fiatjaf/lightningd-gjson-rpc/plugin.(*Plugin).Listener
	/go/pkg/mod/github.com/fiatjaf/lightningd-gjson-rpc@v1.0.1/plugin/plugin.go:182 +0xa9a
```