### PR TITLE
Spark v0.3 support

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ func main() {
 			connectFund,
 			closeGet,
 			listpaysExt,
+			listinvoicesExt,
+			listconfigsExt,
+			decodecheckExt,
 		},
 		Subscriptions: []plugin.Subscription{
 			subscribeSSE("channel_opened"),


### PR DESCRIPTION
I'm not a Go developer, and Spark is pretty much an abandonware, so I don't know why am I doing this (and if), but the older version of `Spark` (`0.2.17`) is unusable on a node with long payments history, so probably you should update it to newer version (`0.3.1`?).

I did some work, but it's not finish. Main issues:
- `decodecheck` is not working for some reason.
- Bolt12 support is not implemented.
- `truncatePayerNotes` not working.
- Other changes, see `TODO` comments.